### PR TITLE
GH-42 Tree DataControl should occupy all height in SplitPane in stories from Tree-Table-Chart

### DIFF
--- a/src/data-controls/TreeRenderer.tsx
+++ b/src/data-controls/TreeRenderer.tsx
@@ -18,7 +18,9 @@ import { TreeContextMenu } from './TreeContextMenu';
 import './styles.css';
 
 const divStyle: React.CSSProperties = {
+  height: '100%',
   padding: '5px',
+  overflow: 'scroll',
 };
 
 export const TreeRenderer: React.FC<any> = (props) => {


### PR DESCRIPTION
Closes #42 